### PR TITLE
Fixed instruction in configure branch policies in setup DevOps doc

### DIFF
--- a/docs/Deploy/setup-azuredevops.md
+++ b/docs/Deploy/setup-azuredevops.md
@@ -48,7 +48,7 @@ The build service account `<Project> Build Service (<Organization>)` must have t
 
 ### Configure branch policies
 
-In order for the pull pipeline to run, set the `main` branch to require build verification.
+In order for the push pipeline to run, set the `main` branch to require build verification.
 
 https://docs.microsoft.com/en-us/azure/devops/repos/git/branch-policies
 


### PR DESCRIPTION
This PR includes a change on the Azure DevOps setup guide where the sentence "In order for the pull pipeline to run, set the main branch to require build verification." should be "In order for the push pipeline to run, set the main branch to require build verification."

Following the current instruction leads to a non-functioning push pipeline, as it is not executed.

Closes Azure/Azure-Landing-Zones#3351